### PR TITLE
Mock stores for App.test

### DIFF
--- a/front/src/App.test.js
+++ b/front/src/App.test.js
@@ -1,9 +1,18 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 
-it('renders without crashing', () => {
-  const div = document.createElement('div');
+import stores from "./stores";
+
+jest.mock("./stores", () => {
+  return {
+    gradientTokenStore: { tokens: [] },
+    modalStore: { hideModal: jest.fn(), modal: { show: false } }
+  };
+});
+
+it("renders without crashing", () => {
+  const div = document.createElement("div");
   ReactDOM.render(<App />, div);
   ReactDOM.unmountComponentAtNode(div);
 });


### PR DESCRIPTION
`App.test.js` was using real stores. Caused crash if ethereum node was not running.